### PR TITLE
fix: make IssueCard responsive for mobile viewports

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,7 +34,7 @@
   }
 
   .card {
-    @apply bg-white rounded-lg shadow-sm border border-gray-200 p-4;
+    @apply bg-white rounded-lg shadow-sm border border-gray-200 p-3 sm:p-4;
   }
 
   .badge {

--- a/src/components/IssueCard.tsx
+++ b/src/components/IssueCard.tsx
@@ -136,18 +136,20 @@ export function IssueCard({
 
   return (
     <div className="card">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <div className="flex items-center gap-2 mb-2">
-            <h3 className="text-lg font-medium text-gray-900">{issue.title}</h3>
-            <span className={`badge-${issue.priority.toLowerCase()}`}>
-              {priorityLabels[issue.priority as IssuePriority]}
-            </span>
-            {issue.storyPoints && (
-              <span className="px-2 py-0.5 bg-purple-100 text-purple-800 rounded-full text-xs font-medium">
-                {issue.storyPoints} {issue.storyPoints === 1 ? 'pt' : 'pts'}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-2">
+            <h3 className="text-lg font-medium text-gray-900 truncate">{issue.title}</h3>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <span className={`badge-${issue.priority.toLowerCase()}`}>
+                {priorityLabels[issue.priority as IssuePriority]}
               </span>
-            )}
+              {issue.storyPoints && (
+                <span className="px-2 py-0.5 bg-purple-100 text-purple-800 rounded-full text-xs font-medium">
+                  {issue.storyPoints} {issue.storyPoints === 1 ? 'pt' : 'pts'}
+                </span>
+              )}
+            </div>
           </div>
           <p className="text-gray-600 mb-3">{issue.description}</p>
           <div className="flex items-center gap-4 text-sm">
@@ -161,7 +163,7 @@ export function IssueCard({
             </span>
           </div>
         </div>
-        <div className="flex gap-2 ml-4">
+        <div className="flex flex-col sm:flex-row gap-2 sm:ml-4">
           {getNextStatus() && (
             <button
               onClick={handleStatusChange}


### PR DESCRIPTION
## Summary

Fixed IssueCard layout overflow issues on mobile viewports by implementing responsive design patterns.

## Changes

- ✅ Outer container uses `flex-col sm:flex-row` for mobile-first layout
- ✅ Added title truncation with ellipsis
- ✅ Badges stack vertically on mobile (< 640px), horizontal on tablet+
- ✅ Action buttons stack vertically on mobile
- ✅ Reduced card padding on mobile (12px vs 16px)
- ✅ Added `min-w-0` to prevent flex child overflow

## Testing

Please test on the following viewports:
- 📱 Mobile (375px): Vertical stacking, truncated titles, compact layout
- 💻 Tablet (768px): Horizontal layout, full titles
- 🖥️ Desktop (1280px): Original layout preserved

Closes #9

---

🤖 Generated with [Claude Code](https://claude.ai/code)